### PR TITLE
Upgrade CI Node to 20 and add dependency overrides to resolve transitive issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,44 @@
       },
       "engines": {
         "node": ">=18.0"
+      },
+      "overrides": {
+        "webpack-dev-server": {
+          ".": "5.2.1",
+          "open": "8.4.2",
+          "p-retry": "4.6.2",
+          "rimraf": "3.0.2",
+          "webpack-dev-middleware": "5.3.4",
+          "ws": "8.18.2"
+        },
+        "brace-expansion": "2.0.2",
+        "on-headers": "1.1.0",
+        "shell-quote": "1.8.4",
+        "node-forge": "1.3.3",
+        "minimatch": "3.1.4",
+        "picomatch": "2.3.2",
+        "lodash": "4.17.23",
+        "serialize-javascript": "7.0.4",
+        "svgo": "3.3.3",
+        "fast-uri": "3.1.2",
+        "@babel/plugin-transform-modules-systemjs": "7.29.4",
+        "npm": {
+          "glob": "10.5.0",
+          "minimatch": "9.0.7",
+          "tar": "7.5.7"
+        },
+        "@docusaurus/utils": {
+          "js-yaml": "4.1.1"
+        },
+        "@docusaurus/utils-validation": {
+          "js-yaml": "4.1.1"
+        },
+        "@docusaurus/plugin-content-docs": {
+          "js-yaml": "4.1.1"
+        },
+        "cosmiconfig": {
+          "js-yaml": "4.1.1"
+        }
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -1197,9 +1235,8 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
-      "integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -5480,13 +5517,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -7770,9 +7805,8 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "funding": [
         {
           "type": "github",
@@ -9714,9 +9748,8 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9906,9 +9939,8 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -12352,9 +12384,8 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -12459,9 +12490,8 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -13146,7 +13176,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.1",
+      "version": "2.0.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13221,7 +13251,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache/node_modules/tar": {
-      "version": "7.4.3",
+      "version": "7.5.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13471,7 +13501,7 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.4.5",
+      "version": "10.5.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13888,7 +13918,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14119,7 +14149,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
-      "version": "7.4.3",
+      "version": "7.5.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14782,7 +14812,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.2.1",
+      "version": "7.5.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14794,7 +14824,7 @@
         "yallist": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
@@ -15216,9 +15246,8 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -15559,9 +15588,8 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -18337,10 +18365,12 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -18491,9 +18521,8 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -18676,9 +18705,8 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -19191,18 +19219,17 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
-      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
       "license": "MIT",
       "dependencies": {
-        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^5.1.0",
         "css-tree": "^2.3.1",
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.0.0",
+        "sax": "^1.5.0"
       },
       "bin": {
         "svgo": "bin/svgo"
@@ -20131,60 +20158,59 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-      "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.1.tgz",
       "license": "MIT",
       "dependencies": {
-        "@types/bonjour": "^3.5.9",
-        "@types/connect-history-api-fallback": "^1.3.5",
-        "@types/express": "^4.17.13",
-        "@types/serve-index": "^1.9.1",
-        "@types/serve-static": "^1.13.10",
-        "@types/sockjs": "^0.3.33",
-        "@types/ws": "^8.5.5",
+        "@types/bonjour": "^3.5.13",
+        "@types/connect-history-api-fallback": "^1.5.4",
+        "@types/express": "^4.17.21",
+        "@types/serve-index": "^1.9.4",
+        "@types/serve-static": "^1.15.5",
+        "@types/sockjs": "^0.3.36",
+        "@types/ws": "^8.5.10",
         "ansi-html-community": "^0.0.8",
-        "bonjour-service": "^1.0.11",
-        "chokidar": "^3.5.3",
+        "bonjour-service": "^1.2.1",
+        "chokidar": "^3.6.0",
         "colorette": "^2.0.10",
         "compression": "^1.7.4",
         "connect-history-api-fallback": "^2.0.0",
         "default-gateway": "^6.0.3",
         "express": "^4.17.3",
         "graceful-fs": "^4.2.6",
-        "html-entities": "^2.3.2",
+        "html-entities": "^2.4.0",
         "http-proxy-middleware": "^2.0.3",
-        "ipaddr.js": "^2.0.1",
-        "launch-editor": "^2.6.0",
-        "open": "^8.0.9",
-        "p-retry": "^4.5.0",
-        "rimraf": "^3.0.2",
-        "schema-utils": "^4.0.0",
-        "selfsigned": "^2.1.1",
+        "ipaddr.js": "^2.1.0",
+        "launch-editor": "^2.6.1",
+        "open": "8.4.2",
+        "p-retry": "4.6.2",
+        "rimraf": "3.0.2",
+        "schema-utils": "^4.2.0",
+        "selfsigned": "^2.4.1",
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
-        "webpack-dev-middleware": "^5.3.4",
-        "ws": "^8.13.0"
+        "webpack-dev-middleware": "5.3.4",
+        "ws": "8.18.2"
       },
       "bin": {
         "webpack-dev-server": "bin/webpack-dev-server.js"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^4.37.0 || ^5.0.0"
+        "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "webpack": {
+        "webpack-cli": {
           "optional": true
         },
-        "webpack-cli": {
+        "webpack": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,43 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "overrides": {
+    "webpack-dev-server": {
+      ".": "5.2.1",
+      "open": "8.4.2",
+      "p-retry": "4.6.2",
+      "rimraf": "3.0.2",
+      "webpack-dev-middleware": "5.3.4",
+      "ws": "8.18.2"
+    },
+    "brace-expansion": "2.0.2",
+    "on-headers": "1.1.0",
+    "shell-quote": "1.8.4",
+    "node-forge": "1.3.3",
+    "minimatch": "3.1.4",
+    "picomatch": "2.3.2",
+    "lodash": "4.17.23",
+    "serialize-javascript": "7.0.4",
+    "svgo": "3.3.3",
+    "fast-uri": "3.1.2",
+    "@babel/plugin-transform-modules-systemjs": "7.29.4",
+    "npm": {
+      "glob": "10.5.0",
+      "minimatch": "9.0.7",
+      "tar": "7.5.7"
+    },
+    "@docusaurus/utils": {
+      "js-yaml": "4.1.1"
+    },
+    "@docusaurus/utils-validation": {
+      "js-yaml": "4.1.1"
+    },
+    "@docusaurus/plugin-content-docs": {
+      "js-yaml": "4.1.1"
+    },
+    "cosmiconfig": {
+      "js-yaml": "4.1.1"
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- Upgrade CI Node to 20 to match current runtime expectations and support updated dependencies.
- Pin/override transitive dependencies to patched versions to address compatibility and potential security issues for the Docusaurus site build.

### Description
- Updated `.github/workflows/deploy.yml` and `.github/workflows/test_deploy.yml` to use `actions/setup-node@v4` with `node-version: 20` instead of 18.
- Added an `overrides` section to `package.json` (and corresponding entries in `package-lock.json`) to pin multiple transitive packages, including `webpack-dev-server` -> `5.2.1`, `js-yaml` -> `4.1.1`, `lodash` -> `4.17.23`, `serialize-javascript` -> `7.0.4`, `svgo` -> `3.3.3`, `node-forge` -> `1.3.3`, and several others to specific safe/compatible versions.
- Bumped and normalized several lockfile entries to reflect the overrides and tightened engine requirements for some packages where applicable.
- Retained the top-level `engines.node` of `>=18.0` while applying overrides to ensure compatibility with Node 20 in CI.

### Testing
- The CI/test deployment workflow is configured to run `npm ci` and `npm run build` (as defined in `test_deploy.yml`) to validate the site build under Node 20.
- No automated test run results were provided in the rollout transcript, so pass/fail status of CI runs is not available in this change record.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2876d69f68833087b11f8719bd709c)