### PR TITLE
Fix high dependency alerts for node-forge, lodash, and path-to-regexp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7692,9 +7692,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/express/node_modules/range-parser": {
@@ -9879,8 +9879,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -12430,8 +12431,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"

--- a/package.json
+++ b/package.json
@@ -53,13 +53,16 @@
       "webpack-dev-middleware": "5.3.4",
       "ws": "8.18.2"
     },
+    "node-forge": "1.4.0",
+    "lodash": "4.18.1",
+    "express": {
+      "path-to-regexp": "0.1.13"
+    },
     "brace-expansion": "2.0.2",
     "on-headers": "1.1.0",
     "shell-quote": "1.8.4",
-    "node-forge": "1.3.3",
     "minimatch": "3.1.4",
     "picomatch": "2.3.2",
-    "lodash": "4.17.23",
     "serialize-javascript": "7.0.4",
     "svgo": "3.3.3",
     "fast-uri": "3.1.2",


### PR DESCRIPTION
Applies targeted dependency overrides for:
- node-forge 1.4.0
- lodash 4.18.1
- express -> path-to-regexp 0.1.13

Local checks passed:
- npm install
- npm ci
- npm run build