### PR TITLE
Fix serialize-javascript moderate alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14738,15 +14738,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -15915,11 +15906,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "shell-quote": "1.8.4",
     "minimatch": "3.1.4",
     "picomatch": "2.3.2",
-    "serialize-javascript": "7.0.4",
+    "serialize-javascript": "7.0.5",
     "svgo": "3.3.3",
     "fast-uri": "3.1.2",
     "@babel/plugin-transform-modules-systemjs": "7.29.4",


### PR DESCRIPTION
Updates the serialize-javascript override from 7.0.4 to 7.0.5.

Local checks passed:
- npm install
- npm ci
- npm run build